### PR TITLE
Regression fix, documentation, tests, refactoring and other fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## 0.18
+
+### Added
+
+- Task added to the `verification` group, so it is listed in the `gradle tasks` output.
+- Changelog
+- Release process documented
+- Compatibility info to the README
+- JavaDoc and describe undocumented parameters.
+- Additional tests, including parallel run
+
+### Changed
+
+- Cucumber-reporting upgraded to the latest version
+- Do not use deprecated Cucumber API and use new `tags` syntax
+- Use Gradle logger instead of Slf4j
+
+### Fixed
+
+Regression for non-standard suite name
+
+## [0.17] - 2019-11-25
+
+### Added
+- Gradle 6 and 7 compatibility
+
+### Changed
+
+- Plugin name changed to `com.patdouble.cucumber-jvm`
+- The minimum required Java version is 8
+
+### Removed
+
+- Support for Java 7
+- Support for very old Gradle versions
+
+### Fixed
+
+- Fix path to the failure file
+
+## [0.14]
+
+- Initial fork from [commercehub-oss/gradle-cucumber-jvm-plugin](https://github.com/commercehub-oss/gradle-cucumber-jvm-plugin).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing
 
-> Before contributing, please read our [code of conduct](https://github.com/commercehub-oss/gradle-cucumber-jvm-plugin/blob/master/CODE_OF_CONDUCT.md).
+> Before contributing, please read our [code of conduct](https://github.com/double16/gradle-cucumber-jvm-plugin/blob/master/CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Gradle Cucumber-JVM Plugin
 
-[![Build Status](https://travis-ci.org/commercehub-oss/gradle-cucumber-jvm-plugin.png?branch=master)](https://travis-ci.org/commercehub-oss/gradle-cucumber-jvm-plugin)
-
-The gradle cucumber-jvm plugin provides the ability to run [cucumber](http://cukes.info) acceptance tests directly
+The gradle cucumber-jvm plugin provides the ability to run [cucumber](http://cucumber.io) acceptance tests directly
 from a gradle build.  The plugin utilizes the cucumber cli provided by the [cucumber-jvm](https://github.com/cucumber/cucumber-jvm) 
 project, while imposing a few constraints to encourage adopters to use cucumber in a gradle friendly manner. Some of
 constraints include:
@@ -16,9 +14,16 @@ The inspiration for this plugin drew heavily from the work of
 [Samuel Brown's Cucumber Plugin](https://github.com/samueltbrown/gradle-cucumber-plugin) and 
 [Camilo Ribeiro's Cucumber Gradle Parallel Example](https://github.com/camiloribeiro/cucumber-gradle-parallel).
 
+## Compatibility
+
+Tested with Gradle versions: 6.0. Should work with Gradle 7.+ (not released yet at the time of writing this document).
+Cucumber 4.3 or later, recommended 4.8.+.
+At least Java 8 required.
+
 ## Contributors
 
  * [Jay St.Gelais](http://github.com/JayStGelais)
+ * Fork from: [commercehub-oss/gradle-cucumber-jvm-plugin](https://github.com/commercehub-oss/gradle-cucumber-jvm-plugin)
 
 ## Using the plugin in your gradle build script
 
@@ -26,27 +31,13 @@ The following gradle configuration will create a new Cucumber based test suite n
 to run up to 3 parallel forks. The `cucumberTest` source set will depend on the project's main source set.
 
 ```groovy
-buildscript {
-    repositories {
-        maven {
-            url "http://repo.bodar.com"
-        }
-        maven {
-          url "https://plugins.gradle.org/m2/"
-        }
-    }
-    dependencies {
-        classpath "com.patdouble:gradle-cucumber-jvm-plugin:0.16"
-    }
-}
 plugins {
     id 'java'
-    id 'com.patdouble.cucumber-jvm' version '0.16'
+    id 'com.patdouble.cucumber-jvm' version '0.17'
 }
 
-  
 addCucumberSuite 'cucumberTest'
-  
+
 cucumber {
     maxParallelForks = 3
 }
@@ -63,10 +54,25 @@ repositories {
 }
 
 dependencies {
-    cucumberTestCompile 'info.cukes:cucumber-java:1.2.2'
+    cucumberTestCompile 'io.cucumber:cucumber-java:4.8.0'
     // To use JUnit assertions in the step definitions:
     cucumberTestCompile 'junit:junit:4.12'
 }
+```
+
+Using legacy plugin application:
+```groovy
+buildscript {
+    repositories {
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
+    }
+    dependencies {
+        classpath "com.patdouble:gradle-cucumber-jvm-plugin:0.17"
+    }
+}
+apply plugin: 'cucumber-jvm'
 ```
 
 The corresponding directory layout will look like this:
@@ -99,7 +105,7 @@ An example `build.gradle.kts` file might look like this:
 ```kotlin
 plugins {
     id("java")
-    id("com.patdouble.cucumber-jvm").version("0.16")
+    id("com.patdouble.cucumber-jvm").version("0.17")
 }
 
 cucumber {
@@ -112,7 +118,7 @@ repositories {
 }
 
 dependencies {
-    add("cucumberTestCompile", "info.cukes:cucumber-java:1.2.2")
+    add("cucumberTestCompile", "io.cucumber:cucumber-java:4.8.0")
     add("cucumberTestCompile", "junit:junit:4.12")
 }
 ```
@@ -126,18 +132,47 @@ via the `add()` function.
 
 Cucumber tasks can be configured at two levels, globally for the project and individually for a test suite. This allows
 for projects to contain multiple Cucumber test suites that can differ on some properties while inheriting other
-property values form the project defaults. Both levels of configuration make the following settings available:
-
+property values form the project defaults.
+ 
+Both levels of configuration make the following settings available:
+* `suite("someName")`: Method to register a new suite. This can be used as an alternative to calling `addCucumberSuite()`. If you use the Kotlin DSL it is the only way to register a suite.
 * `stepDefinitionRoots`: A list of root packages to scan the classpath for glue code. Defaults to `['cucumber.steps', 'cucumber.hooks']`.
 * `featureRoots`: A list of root packages to scan the resources folders on the classpath for feature files. Defaults to `['features']`.
 * `tags`: A list of tags to identify scenarios to run. Default to an empty list.
 * `plugins`: A list of cucumber plugins passed for execution. Defaults to an empty list.
 * `isStrict`: A boolean value indicating whether scenarios should be evaluated strictly. Defaults to `false`.
-* `snippits`: Indicator to cucumber on what style to use for generated step examples. Valid values include `camelcase`, `underscore`. Defaults to `camelcase`.
+* `snippets`: Indicator to cucumber on what style to use for generated step examples. Valid values include `camelcase`, `underscore`. Defaults to `camelcase`.
 * `maxParallelForks`: Maximum number of forked Java processes to start to run tests in parallel. Defaults to `1`.
 * `jvmArgs`: List of custom jvm arguments to pass to test execution
-* `systemProperties`: Map of properties to values (String → String) to pass to the forked test running JVMs as Java system properties.
-* `suite("someName")`: Method to register a new suite. This can be used as an alternative to calling `addCucumberSuite()`. If you use the Kotlin DSL it is the only way to register a suite.
+* `isMonochrome`: A boolean value indicating whether terminal output should be without colours. Defaults to `false`.
+* `isDryRun`: A boolean value indicating whether glue code execution should be skipped. Defaults to `false`.
+* `ignoreFailures`: Property to cause or prevent build failure when cucumber tests fail. Defaults to `false`.
+* `junitReport`: Property to enable/disable JUnit reporting. Defaults to `false`.
+
+Setting available in tasks only:
+* `systemProperties`: Map of properties to values (String → String) to pass to the forked test running JVMs as Java system properties. Defaults to empty map.
+* `jvmArgs`: List of arguments to pass to the forked test running JVMs. Defaults to empty list.
+
+Example:
+```groovy
+// global configuration
+cucumber {
+    suite("smokeCucumberTest")
+    suite("otherCucumberTest")
+    maxParallelForks = 3
+}
+
+// tasks configuration
+smokeCucumberTest {
+    maxParallelForks = 1 // overrides global configuration
+    tags = ['@smoke']
+    jvmArgs = ['-Xmx1G']
+}
+
+otherCucumberTest {
+    systemProperties = ['logback.configurationFile' : 'logback-cucumber.xml']
+}
+```
 
 ### Reporting
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,9 @@
+# Releasing
+
+## Environment setup
+
+Follow the [Publishing Plugins to the Gradle Plugin Portal](https://guides.gradle.org/publishing-plugins-to-gradle-plugin-portal/) instruction.
+
+## Publishing
+
+Run `./gradlew publishPlugins --console=plain`. Answer to all questions asked in the process.

--- a/build.gradle
+++ b/build.gradle
@@ -12,9 +12,8 @@ plugins {
     id 'com.github.ben-manes.versions' version '0.27.0'
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
-
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 repositories {
     jcenter()
@@ -33,7 +32,7 @@ repositories {
  */
 def shadowExcludeDependencies = [
     'org.codehaus.gpars:gpars:1.2.1',
-    'org.zeroturnaround:zt-exec:1.10',
+    'org.zeroturnaround:zt-exec:1.11',
     'org.apache.logging.log4j:log4j-core:2.8.2',
     'org.apache.logging.log4j:log4j-api:2.8.2',
     'com.fasterxml.jackson.core:jackson-databind:2.9.6',
@@ -50,7 +49,7 @@ def shadowExcludeDependencies = [
 dependencies {
     shadow gradleApi()
 
-    implementation('net.masterthought:cucumber-reporting:3.20.0') {
+    implementation('net.masterthought:cucumber-reporting:4.11.2') {
         shadowExcludeDependencies.each {
             def split = it.split(':')
             exclude(group: split[0], module: split[1])

--- a/src/integTest/groovy/com/commercehub/gradle/cucumber/CucumberIntegrationSpec.groovy
+++ b/src/integTest/groovy/com/commercehub/gradle/cucumber/CucumberIntegrationSpec.groovy
@@ -1,6 +1,5 @@
 package com.commercehub.gradle.cucumber
 
-import groovy.util.logging.Slf4j
 import nebula.test.IntegrationSpec
 import nebula.test.functional.ExecutionResult
 
@@ -8,7 +7,6 @@ import nebula.test.functional.ExecutionResult
  * Created by jgelais on 11/19/15.
  */
 @SuppressWarnings('DuplicateStringLiteral')
-@Slf4j
 class CucumberIntegrationSpec extends IntegrationSpec {
 
     @Override
@@ -36,8 +34,8 @@ class CucumberIntegrationSpec extends IntegrationSpec {
             }
 
             dependencies {
-                implementation 'org.codehaus.groovy:groovy-all:2.4.1'
-                implementation 'info.cukes:cucumber-java:1.2.2'
+                implementation 'org.codehaus.groovy:groovy-all:2.5.8'
+                implementation 'io.cucumber:cucumber-java:4.8.0'
             }
 
             test {
@@ -52,13 +50,12 @@ class CucumberIntegrationSpec extends IntegrationSpec {
 
         when:
         ExecutionResult result = runTasksSuccessfully('test')
-        log.info(result.standardOutput)
 
         then:
         !result.wasUpToDate(':compileTestGroovy')
         result.wasExecuted(':test')
-        new File(projectDir, 'build/reports/test').list().flatten()*.replace('\\', '/')
-            .findResults { it.matches('report-feature_features-happypath-feature?\\.html') ? it : null } != null
+        new File(projectDir, 'build/reports/test/cucumber-html-reports').list().flatten()*.replace('\\', '/')
+                .findResults { it.matches('report-feature_features-happypath-feature?\\.html') ? it : null } != null
     }
 
     def testFailingBackgroundStep() {
@@ -68,7 +65,6 @@ class CucumberIntegrationSpec extends IntegrationSpec {
 
         when:
         ExecutionResult result = runTasksWithFailure('test')
-        log.info(result.standardOutput)
 
         then:
         fileExists('build/reports/test/cucumber-html-reports/overview-failures.html')
@@ -81,7 +77,6 @@ class CucumberIntegrationSpec extends IntegrationSpec {
 
         when:
         ExecutionResult result = runTasksSuccessfully('test')
-        log.info(result.standardOutput)
 
         then:
         result.wasExecuted(':test')
@@ -93,9 +88,20 @@ class CucumberIntegrationSpec extends IntegrationSpec {
 
         when:
         ExecutionResult result = runTasksSuccessfully('test')
-        log.info(result.standardOutput)
 
         then:
         result.wasExecuted(':test')
     }
+
+    def testReportsDirectoryCreated() {
+        given:
+        copyResources('testfeatures/happypath.feature', 'src/test/resoucres/features/happypath.feature')
+
+        when:
+        ExecutionResult result = runTasksSuccessfully('test')
+
+        then:
+        fileExists('build/reports/test/cucumber-html-reports/overview-features.html')
+    }
+
 }

--- a/src/integTest/groovy/com/commercehub/gradle/cucumber/CucumberIntegrationSpec.groovy
+++ b/src/integTest/groovy/com/commercehub/gradle/cucumber/CucumberIntegrationSpec.groovy
@@ -3,7 +3,6 @@ package com.commercehub.gradle.cucumber
 import groovy.util.logging.Slf4j
 import nebula.test.IntegrationSpec
 import nebula.test.functional.ExecutionResult
-import org.gradle.api.GradleException
 
 /**
  * Created by jgelais on 11/19/15.
@@ -68,11 +67,12 @@ class CucumberIntegrationSpec extends IntegrationSpec {
                 'src/test/resources/features/failing-background-test.feature')
 
         when:
-        ExecutionResult result = runTasksSuccessfully('test')
+        ExecutionResult result = runTasksWithFailure('test')
         log.info(result.standardOutput)
 
         then:
-        thrown GradleException
+        fileExists('build/reports/test/cucumber-html-reports/overview-failures.html')
+        result.standardError.contains("build/reports/test/cucumber-html-reports/overview-failures.html")
     }
 
     def testSysProps() {

--- a/src/integTest/groovy/com/commercehub/gradle/cucumber/CucumberParallelSpec.groovy
+++ b/src/integTest/groovy/com/commercehub/gradle/cucumber/CucumberParallelSpec.groovy
@@ -1,0 +1,131 @@
+package com.commercehub.gradle.cucumber
+
+import nebula.test.IntegrationSpec
+import nebula.test.functional.ExecutionResult
+
+@SuppressWarnings('DuplicateStringLiteral')
+class CucumberParallelSpec extends IntegrationSpec {
+
+    @Override
+    protected List<String> calculateArguments(String... args) {
+        def newArgs = ['--warning-mode', 'all']
+        if (args) {
+            newArgs.addAll(args)
+        }
+        super.calculateArguments(newArgs as String[])
+    }
+
+    def setup() {
+        copyResources('teststeps/TestSteps.groovy', 'src/cucumberTest/groovy/cucumber/steps/TestSteps.groovy')
+        buildFile << '''
+            apply plugin: 'groovy'
+            apply plugin: 'com.patdouble.cucumber-jvm'
+
+            addCucumberSuite 'cucumberTest'
+
+            cucumber {
+                tags = ["@test", "@happypath", "~@ignore"]
+                maxParallelForks = 2
+            }
+
+            repositories {
+                jcenter()
+            }
+
+            dependencies {
+                implementation 'org.codehaus.groovy:groovy-all:2.5.8'
+                implementation 'io.cucumber:cucumber-java:4.8.0'
+            }
+
+            cucumberTest {
+                systemProperty 'foo', 'bar'
+                junitReport true
+            }
+        '''.stripIndent()
+    }
+
+    def testHappyPath() {
+        given:
+        copyResources('testfeatures/happypath.feature', 'src/cucumberTest/resources/features/happypath.feature')
+        copyResources('testfeatures/happypath.feature', 'src/cucumberTest/resources/features/happypath1.feature')
+        copyResources('testfeatures/happypath.feature', 'src/cucumberTest/resources/features/happypath2.feature')
+        copyResources('testfeatures/happypath.feature', 'src/cucumberTest/resources/features/happypath3.feature')
+
+        when:
+        ExecutionResult result = runTasksSuccessfully('cucumberTest')
+
+        then:
+        result.wasExecuted(':cucumberTest')
+    }
+
+    def testFailingBackgroundStep() {
+        given:
+        copyResources('testfeatures/failing-background-test.feature',
+                'src/cucumberTest/resources/features/failing-background-test.feature')
+        copyResources('testfeatures/failing-background-test.feature',
+                'src/cucumberTest/resources/features/failing-background-test1.feature')
+        copyResources('testfeatures/happypath.feature', 'src/cucumberTest/resources/features/happypath.feature')
+        copyResources('testfeatures/happypath.feature', 'src/cucumberTest/resources/features/happypath1.feature')
+
+        when:
+        ExecutionResult result = runTasksWithFailure('cucumberTest')
+
+        then:
+        fileExists('build/reports/cucumberTest/cucumber-html-reports/overview-failures.html')
+        result.standardError.contains("build/reports/cucumberTest/cucumber-html-reports/overview-failures.html")
+    }
+
+    def testSysProps() {
+        given:
+        copyResources('testfeatures/check-sysprop.feature',
+                'src/cucumberTest/resources/features/check-sysprop.feature')
+        copyResources('testfeatures/check-sysprop.feature',
+                'src/cucumberTest/resources/features/check-sysprop1.feature')
+        copyResources('testfeatures/happypath.feature', 'src/cucumberTest/resources/features/happypath1.feature')
+        copyResources('testfeatures/happypath.feature', 'src/cucumberTest/resources/features/happypath2.feature')
+
+        when:
+        ExecutionResult result = runTasksSuccessfully('cucumberTest')
+
+        then:
+        result.wasExecuted(':cucumberTest')
+    }
+
+    def ignoreScenario() {
+        given:
+        copyResources('testfeatures/ignored-test.feature', 'src/cucumberTest/resources/features/ignored-test.feature')
+        copyResources('testfeatures/ignored-test.feature', 'src/cucumberTest/resources/features/ignored-test1.feature')
+        copyResources('testfeatures/happypath.feature', 'src/cucumberTest/resources/features/happypath.feature')
+        copyResources('testfeatures/happypath.feature', 'src/cucumberTest/resources/features/happypath1.feature')
+
+        when:
+        ExecutionResult result = runTasksSuccessfully('cucumberTest')
+
+        then:
+        result.wasExecuted(':cucumberTest')
+    }
+
+    def testReportsDirectoryCreated() {
+        given:
+        copyResources('testfeatures/happypath.feature', 'src/cucumberTest/resoucres/features/happypath.feature')
+
+        when:
+        ExecutionResult result = runTasksSuccessfully('cucumberTest')
+
+        then:
+        fileExists('build/reports/cucumberTest/cucumber-html-reports/overview-features.html')
+    }
+
+    def testJunitReport() {
+        given:
+        copyResources('testfeatures/happypath.feature', 'src/cucumberTest/resources/features/happypath.feature')
+
+        when:
+        ExecutionResult result = runTasksSuccessfully('cucumberTest')
+
+        then:
+        fileExists('build/test-results/cucumber/cucumberTest/features.happypath.feature.json')
+        fileExists('build/test-results/cucumber/cucumberTest/features.happypath.feature.xml')
+    }
+
+}

--- a/src/main/groovy/com/commercehub/gradle/cucumber/CommandArgumentsBuilder.groovy
+++ b/src/main/groovy/com/commercehub/gradle/cucumber/CommandArgumentsBuilder.groovy
@@ -1,0 +1,106 @@
+package com.commercehub.gradle.cucumber
+
+class CommandArgumentsBuilder {
+
+    private static final String PLUGIN = '--plugin'
+    private static final String TILDE = '~'
+    private static final String TAGS = '--tags '
+
+    private List<String> args = []
+    private CucumberRunnerOptions options
+
+    CommandArgumentsBuilder(CucumberRunnerOptions options) {
+        this.options = options
+    }
+
+    List<String> buildArguments(File featureFile, File resultsFile, File junitResultsFile) {
+        applyGlueArguments()
+        applyPluginArguments(resultsFile, junitResultsFile)
+        applyDryRunArguments()
+        applyMonochromeArguments()
+        applyStrictArguments()
+        applyTagsArguments()
+        applySnippetArguments()
+        args << featureFile.absolutePath
+        return args
+    }
+
+    private List<String> applyGlueArguments() {
+        options.stepDefinitionRoots.each {
+            args << '--glue'
+            args << it
+        }
+    }
+
+    private void applyPluginArguments(File resultsFile, File junitResultsFile) {
+        args << PLUGIN
+        args << 'pretty'
+        args << PLUGIN
+        args << "json:${resultsFile.absolutePath}"
+        if (options.junitReport) {
+            args << PLUGIN
+            args << "junit:${junitResultsFile.absolutePath}"
+        }
+        if (!options.plugins.empty) {
+            options.plugins.each {
+                args << PLUGIN
+                args << it
+            }
+        }
+    }
+
+    private void applyDryRunArguments() {
+        if (options.isDryRun) {
+            args << '--dry-run'
+        }
+    }
+
+    private void applyMonochromeArguments() {
+        if (options.isMonochrome) {
+            args << '--monochrome'
+        }
+    }
+
+    private void applyStrictArguments() {
+        if (options.isStrict) {
+            args << '--strict'
+        }
+    }
+
+    protected void applyTagsArguments() {
+        if (!options.tags.isEmpty()) {
+            applyTagsToCheck()
+            applyTagsToIgnore()
+        }
+    }
+
+    private void applyTagsToCheck() {
+        def tagsToCheck = ''
+        def hasTags = false
+        options.tags.each {
+            if (!it.contains(TILDE)) {
+                tagsToCheck += it + ' or '
+                hasTags = true
+            }
+        }
+        if (hasTags) {
+            args << TAGS
+            args << tagsToCheck[0..-5]
+        }
+    }
+
+    private void applyTagsToIgnore() {
+        options.tags.each {
+            if (it.contains(TILDE)) {
+                args << TAGS
+                args << it.replaceFirst(TILDE, 'not ')
+            }
+        }
+    }
+
+    private void applySnippetArguments() {
+        args << '--snippets'
+        args << options.snippets
+    }
+
+}

--- a/src/main/groovy/com/commercehub/gradle/cucumber/CucumberExtension.groovy
+++ b/src/main/groovy/com/commercehub/gradle/cucumber/CucumberExtension.groovy
@@ -3,65 +3,61 @@ package com.commercehub.gradle.cucumber
 import org.gradle.api.Project
 
 /**
- * Created by jgelais on 6/11/15.
+ * The gradle cucumber-jvm plugin provides the ability to run cucumber acceptance tests directly from a gradle build.
  */
 class CucumberExtension {
     /**
-     * Tags used to filter which scenarios should be run.
-     *
-     * Defaults to an empty list.
+     * A list of tags to identify scenarios to run. Defaults to an empty list.
      */
     List<String> tags = []
 
     /**
-     * Maximum number of parallel threads to run features on.
-     *
-     * Defaults to 1.
+     * Maximum number of forked Java processes to start to run tests in parallel. Defaults to `1`.
      */
     int maxParallelForks = 1
 
     /**
-     *
+     * A list of root packages to scan the classpath for glue code. Defaults to `['cucumber.steps', 'cucumber.hooks']`.
      */
     List<String> stepDefinitionRoots = ['cucumber.steps', 'cucumber.hooks']
 
     /**
-     *
+     * A list of root packages to scan the resources folders on the classpath for feature files. Defaults to `['features']`.
      */
     List<String> featureRoots = ['features']
 
     /**
-     *
+     * A list of cucumber plugins passed for execution. Defaults to an empty list.
      */
     List<String> plugins = []
 
     /**
-     *
+     * A boolean value indicating whether glue code execution should be skipped. Defaults to `false`.
      */
     boolean isDryRun = false
 
     /**
-     *
+     * A boolean value indicating whether terminal output should be without colours. Defaults to `false`.
      */
     boolean isMonochrome = false
 
     /**
-     *
+     * A boolean value indicating whether scenarios should be evaluated strictly. Defaults to `false`.
      */
     boolean isStrict = false
 
     /**
-     *
+     * Indicator to cucumber on what style to use for generated step examples. Valid values include `camelcase`, `underscore`. Defaults to `camelcase`.
      */
     String snippets = 'camelcase'
 
     /**
-     * Property to enable/disable junit reporting
+     * Property to enable/disable JUnit reporting. Defaults to `false`.
      */
     boolean junitReport = false
 
     /**
-     * Property to cause or prevent build failure when cucumber tests fail
+     * Property to cause or prevent build failure when cucumber tests fail. Defaults to `false`.
      */
     boolean ignoreFailures = false
 

--- a/src/main/groovy/com/commercehub/gradle/cucumber/CucumberPlugin.groovy
+++ b/src/main/groovy/com/commercehub/gradle/cucumber/CucumberPlugin.groovy
@@ -8,7 +8,7 @@ import org.gradle.api.tasks.SourceSet
 import org.gradle.plugins.ide.idea.IdeaPlugin
 
 /**
- * This is the main plugin file. Put a description of your plugin here.
+ * The gradle cucumber-jvm plugin provides the ability to run cucumber acceptance tests directly from a Gradle build.
  */
 class CucumberPlugin implements Plugin<Project> {
 

--- a/src/main/groovy/com/commercehub/gradle/cucumber/CucumberPlugin.groovy
+++ b/src/main/groovy/com/commercehub/gradle/cucumber/CucumberPlugin.groovy
@@ -33,11 +33,11 @@ class CucumberPlugin implements Plugin<Project> {
         CucumberTask task
         try {
             task = project.tasks.create(sourceSetName, CucumberTask)
-        } catch (GradleException e) {
+        } catch (GradleException ignored) {
             task = project.tasks.replace(sourceSetName, CucumberTask)
         }
         task.dependsOn cucumberSuiteSourceSet.classesTaskName
-        task.sourceSet = cucumberSuiteSourceSet
+        task.sourceSet(cucumberSuiteSourceSet)
 
         // configure source set in intellij if plugin is applied
         project.plugins.withType(IdeaPlugin) {

--- a/src/main/groovy/com/commercehub/gradle/cucumber/CucumberRunner.groovy
+++ b/src/main/groovy/com/commercehub/gradle/cucumber/CucumberRunner.groovy
@@ -1,6 +1,5 @@
 package com.commercehub.gradle.cucumber
 
-import groovy.util.logging.Slf4j
 import groovyx.gpars.GParsPool
 import net.masterthought.cucumber.Configuration
 import net.masterthought.cucumber.ReportParser
@@ -17,7 +16,6 @@ import java.util.concurrent.atomic.AtomicBoolean
 /**
  * Created by jgelais on 6/16/15.
  */
-@Slf4j
 class CucumberRunner {
     private static final String PLUGIN = '--plugin'
     private static final String TILDE = '~'
@@ -94,7 +92,7 @@ class CucumberRunner {
                 } else {
                     hasFeatureParseErrors.set(true)
                     if (consoleErrLogFile.exists()) {
-                        log.error(consoleErrLogFile.text)
+                        gradleLogger.error(consoleErrLogFile.text)
                     }
                 }
             }
@@ -231,7 +229,7 @@ class CucumberRunner {
     private void handleResult(File resultsFile, File consoleOutLogFile,
                               AtomicBoolean hasFeatureParseErrors, SourceSet sourceSet) {
         List<CucumberFeatureResult> results = parseFeatureResult(resultsFile).collect {
-            log.debug("Logging result for $it.name")
+            gradleLogger.debug("Logging result for $it.name")
             createResult(it)
         }
         results.each { CucumberFeatureResult result ->
@@ -241,7 +239,7 @@ class CucumberRunner {
                 if (result.undefinedSteps > 0) {
                     hasFeatureParseErrors.set(true)
                 }
-                log.error('{}:\r\n {}', sourceSet.name, consoleOutLogFile.text)
+                gradleLogger.error('{}:\r\n {}', sourceSet.name, consoleOutLogFile.text)
             }
         }
     }

--- a/src/main/groovy/com/commercehub/gradle/cucumber/CucumberRunner.groovy
+++ b/src/main/groovy/com/commercehub/gradle/cucumber/CucumberRunner.groovy
@@ -56,6 +56,7 @@ class CucumberRunner {
         AtomicBoolean hasFeatureParseErrors = new AtomicBoolean(false)
 
         def features = findFeatures(sourceSet)
+        def classpath = sourceSet.runtimeClasspath.toList()
 
         testResultCounter.beforeSuite(features.files.size())
         GParsPool.withPool(options.maxParallelForks) {
@@ -76,7 +77,7 @@ class CucumberRunner {
                 applySnippetArguments(args)
                 args << featureFile.absolutePath
 
-                new JavaProcessLauncher('cucumber.api.cli.Main', sourceSet.runtimeClasspath.toList())
+                new JavaProcessLauncher('cucumber.api.cli.Main', classpath)
                         .setArgs(args)
                         .setJvmArgs(jvmArgs)
                         .setConsoleOutLogFile(consoleOutLogFile)

--- a/src/main/groovy/com/commercehub/gradle/cucumber/CucumberRunner.groovy
+++ b/src/main/groovy/com/commercehub/gradle/cucumber/CucumberRunner.groovy
@@ -3,6 +3,7 @@ package com.commercehub.gradle.cucumber
 import groovyx.gpars.GParsPool
 import net.masterthought.cucumber.Configuration
 import net.masterthought.cucumber.ReportParser
+import net.masterthought.cucumber.ReportResult
 import net.masterthought.cucumber.json.Feature
 import org.gradle.api.GradleException
 import org.gradle.api.file.FileTree
@@ -149,7 +150,10 @@ class CucumberRunner {
 
     List<Feature> parseFeatureResult(File jsonReport) {
         configuration.getEmbeddingDirectory().mkdirs()
-        return new ReportParser(configuration).parseJsonFiles([jsonReport.absolutePath])
+        ReportParser reportParser = new ReportParser(configuration);
+        List<Feature> featuresFromJson = reportParser.parseJsonFiles([jsonReport.absolutePath])
+        ReportResult reportResult = new ReportResult(featuresFromJson, configuration)
+        return reportResult.getAllFeatures()
     }
 
     CucumberFeatureResult createResult(Feature feature) {

--- a/src/main/groovy/com/commercehub/gradle/cucumber/CucumberRunner.groovy
+++ b/src/main/groovy/com/commercehub/gradle/cucumber/CucumberRunner.groovy
@@ -56,7 +56,7 @@ class CucumberRunner {
         this.gradleLogger = gradleLogger
     }
 
-    boolean run(SourceSet sourceSet, File resultsDir, File reportsDir) {
+    boolean run(SourceSet sourceSet, File resultsDir) {
         AtomicBoolean hasFeatureParseErrors = new AtomicBoolean(false)
 
         def features = findFeatures(sourceSet)

--- a/src/main/groovy/com/commercehub/gradle/cucumber/CucumberTask.groovy
+++ b/src/main/groovy/com/commercehub/gradle/cucumber/CucumberTask.groovy
@@ -40,6 +40,11 @@ class CucumberTask extends Test implements CucumberRunnerOptions {
     @Input
     Boolean junitReport = null
 
+    CucumberTask() {
+        group = 'verification'
+        description = 'Runs the cucumber tests.'
+    }
+
     @Override
     @TaskAction
     void executeTests() {

--- a/src/main/groovy/com/commercehub/gradle/cucumber/CucumberTask.groovy
+++ b/src/main/groovy/com/commercehub/gradle/cucumber/CucumberTask.groovy
@@ -70,11 +70,7 @@ class CucumberTask extends Test implements CucumberRunnerOptions {
 
     @Internal
     Configuration getConfiguration() {
-        Configuration configuration = new Configuration(getReportsDir(), "${project.name}-${sourceSet.name}")
-        configuration.parallelTesting = true
-        configuration.runWithJenkins = false
-
-        return configuration
+        return new Configuration(getReportsDir(), "${project.name}-${sourceSet.name}")
     }
 
     @SuppressWarnings('ConfusingMethodName')

--- a/src/main/groovy/com/commercehub/gradle/cucumber/CucumberTask.groovy
+++ b/src/main/groovy/com/commercehub/gradle/cucumber/CucumberTask.groovy
@@ -105,7 +105,7 @@ class CucumberTask extends Test implements CucumberRunnerOptions {
     }
 
     private void handleTestFailures() {
-        String reportUrl = new ConsoleRenderer().asClickableFileUrl(new File(getReportsDir(), 'cucumber-html-reports/feature-overview.html'))
+        String reportUrl = new ConsoleRenderer().asClickableFileUrl(new File(getReportsDir(), 'cucumber-html-reports/overview-failures.html'))
         String message = "There were failing tests. See the report at: $reportUrl"
 
         if (ignoreFailures ?: extension.ignoreFailures) {

--- a/src/main/groovy/com/commercehub/gradle/cucumber/CucumberTask.groovy
+++ b/src/main/groovy/com/commercehub/gradle/cucumber/CucumberTask.groovy
@@ -8,8 +8,8 @@ import org.gradle.internal.logging.ConsoleRenderer
 import org.gradle.internal.logging.progress.ProgressLoggerFactory
 
 /**
- * Created by jgelais on 6/11/15.
- * rholman 12/12/15 - added logic to shorten uri in json files to relative path.
+ * Parameters set in task overrides values from global plugin configuration.
+ * @see com.commercehub.gradle.cucumber.CucumberExtension
  */
 class CucumberTask extends Test implements CucumberRunnerOptions {
     public static final String CUCUMBER_REPORTS_DIR = 'cucumber'
@@ -19,24 +19,71 @@ class CucumberTask extends Test implements CucumberRunnerOptions {
     SourceSet sourceSet
     private final CucumberExtension extension = project.extensions[CUCUMBER_EXTENSION_NAME]
 
+    /**
+     * A list of tags to identify scenarios to run. Defaults to global plugin configuration.
+     */
     @Input
     List<String> tags = null
+    /**
+     * Maximum number of forked Java processes to start to run tests in parallel.
+     * Defaults to global plugin configuration.
+     * @see com.commercehub.gradle.cucumber.CucumberExtension#maxParallelForks
+     */
     @Input
     Integer maxParallelForks = null
+    /**
+     * A list of root packages to scan the resources folders on the classpath for feature files.
+     * Defaults to global plugin configuration.
+     * @see com.commercehub.gradle.cucumber.CucumberExtension#featureRoots
+     */
     @Input
     List<String> featureRoots = null
+    /**
+     * A list of root packages to scan the classpath for glue code.
+     * Defaults to global plugin configuration.
+     * @see com.commercehub.gradle.cucumber.CucumberExtension#stepDefinitionRoots
+     */
     @Input
     List<String> stepDefinitionRoots = null
+    /**
+     * A list of cucumber plugins passed for execution.
+     * Defaults to global plugin configuration.
+     * @see com.commercehub.gradle.cucumber.CucumberExtension#plugins
+     */
     @Input
     List<String> plugins = null
+    /**
+     * A boolean value indicating whether glue code execution should be skipped.
+     * Defaults to global plugin configuration.
+     * @see com.commercehub.gradle.cucumber.CucumberExtension#isDryRun
+     */
     @Input
     Boolean isDryRun = null
+    /**
+     * A boolean value indicating whether terminal output should be without colours.
+     * Defaults to global plugin configuration.
+     * @see com.commercehub.gradle.cucumber.CucumberExtension#isMonochrome
+     */
     @Input
     Boolean isMonochrome = null
+    /**
+     * A boolean value indicating whether scenarios should be evaluated strictly.
+     * Defaults to global plugin configuration.
+     * @see com.commercehub.gradle.cucumber.CucumberExtension#isStrict
+     */
     @Input
     Boolean isStrict = null
+    /**
+     * Indicator to cucumber on what style to use for generated step examples. Valid values include `camelcase`, `underscore`.
+     * Defaults to global plugin configuration.
+     * @see com.commercehub.gradle.cucumber.CucumberExtension#snippets
+     */
     @Input
     String snippets = null
+    /**
+     * List of arguments to pass to the forked test running JVMs.
+     * Defaults to empty list.
+     */
     @Input
     Boolean junitReport = null
 

--- a/src/main/groovy/com/commercehub/gradle/cucumber/CucumberTask.groovy
+++ b/src/main/groovy/com/commercehub/gradle/cucumber/CucumberTask.groovy
@@ -2,11 +2,7 @@ package com.commercehub.gradle.cucumber
 
 import net.masterthought.cucumber.Configuration
 import org.gradle.api.GradleException
-import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.OutputFiles
-import org.gradle.api.tasks.SourceSet
-import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.*
 import org.gradle.api.tasks.testing.Test
 import org.gradle.internal.logging.ConsoleRenderer
 import org.gradle.internal.logging.progress.ProgressLoggerFactory
@@ -42,7 +38,7 @@ class CucumberTask extends Test implements CucumberRunnerOptions {
     @Input
     String snippets = null
     @Input
-    boolean junitReport = null
+    Boolean junitReport = null
 
     @Override
     @TaskAction
@@ -87,7 +83,7 @@ class CucumberTask extends Test implements CucumberRunnerOptions {
         this.sourceSet = sourceSet
     }
 
-    @Internal
+    @OutputDirectory
     File getResultsDir() {
         File projectResultsDir = (File) project.property('testResultsDir')
         File cucumberResults = new File(projectResultsDir, CUCUMBER_REPORTS_DIR)
@@ -97,7 +93,7 @@ class CucumberTask extends Test implements CucumberRunnerOptions {
         return sourceSetResults
     }
 
-    @Internal
+    @OutputDirectory
     File getReportsDir() {
         File projectReportsDir = (File) project.property('reportsDir')
         File sourceSetReports = new File(projectReportsDir, sourceSet.name)

--- a/src/main/groovy/com/commercehub/gradle/cucumber/CucumberTask.groovy
+++ b/src/main/groovy/com/commercehub/gradle/cucumber/CucumberTask.groovy
@@ -96,7 +96,7 @@ class CucumberTask extends Test implements CucumberRunnerOptions {
     @TaskAction
     void executeTests() {
         CucumberRunner runner = createRunner()
-        boolean isPassing = runner.run(sourceSet, getResultsDir(), getReportsDir())
+        boolean isPassing = runner.run(sourceSet, getResultsDir())
         new MasterThoughtReportGenerator(this, getConfiguration()).generateReport(jsonReportFiles)
 
         if (!isPassing) {

--- a/src/main/groovy/com/commercehub/gradle/cucumber/CucumberTask.groovy
+++ b/src/main/groovy/com/commercehub/gradle/cucumber/CucumberTask.groovy
@@ -83,6 +83,7 @@ class CucumberTask extends Test implements CucumberRunnerOptions {
 
     @SuppressWarnings('ConfusingMethodName')
     def sourceSet(SourceSet sourceSet) {
+        setTestClassesDirs(sourceSet.output.classesDirs)
         this.sourceSet = sourceSet
     }
 

--- a/src/main/groovy/com/commercehub/gradle/cucumber/JavaProcessLauncher.groovy
+++ b/src/main/groovy/com/commercehub/gradle/cucumber/JavaProcessLauncher.groovy
@@ -1,6 +1,5 @@
 package com.commercehub.gradle.cucumber
 
-import groovy.util.logging.Slf4j
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.Logger
 import org.zeroturnaround.exec.ProcessExecutor
@@ -8,7 +7,6 @@ import org.zeroturnaround.exec.ProcessExecutor
 /**
  * Created by jgelais on 6/17/15.
  */
-@Slf4j
 class JavaProcessLauncher {
     String mainClassName
     List<File> classpath
@@ -97,9 +95,10 @@ class JavaProcessLauncher {
                 OutputStream err = new LoggingOutputStream(gradleLogger, LogLevel.ERROR)
                 streams << err
                 processExecutor.redirectErrorAlsoTo(err)
+
+                gradleLogger.debug("Running command [${command.join(' ')}]")
             }
 
-            log.debug("Running command [${command.join(' ')}]")
             return processExecutor.destroyOnExit().execute().exitValue
         } finally {
             streams*.close()

--- a/src/main/groovy/com/commercehub/gradle/cucumber/LoggingOutputStream.groovy
+++ b/src/main/groovy/com/commercehub/gradle/cucumber/LoggingOutputStream.groovy
@@ -8,7 +8,7 @@ import java.util.concurrent.BlockingQueue
 import java.util.concurrent.LinkedBlockingQueue
 
 /**
- * Sends output to the Slf4j logger.
+ * Sends output to the logger.
  */
 @CompileStatic
 class LoggingOutputStream extends OutputStream implements Closeable {

--- a/src/test/groovy/com/commercehub/gradle/cucumber/CucumberTaskSpec.groovy
+++ b/src/test/groovy/com/commercehub/gradle/cucumber/CucumberTaskSpec.groovy
@@ -15,7 +15,7 @@ class CucumberTaskSpec extends Specification {
 
     def setupSpec() {
         cucumberRunnerMock = GroovyMock(CucumberRunner) {
-            _ * run(_, _, _) >> true
+            _ * run(_, _) >> true
         }
         CucumberTask.metaClass.createRunner = { -> cucumberRunnerMock }
     }


### PR DESCRIPTION
### Added

- Task added to the `verification` group, so it is listed in the `gradle tasks` output.
- Changelog
- Release process documented
- Compatibility info to the README
- JavaDoc and describe undocumented parameters.
- Additional tests, including parallel run

### Changed

- Cucumber-reporting upgraded to the latest version
- Do not use deprecated Cucumber API and use new `tags` syntax
- Use Gradle logger instead of Slf4j

### Fixed

Regression for non-standard suite name