### PR TITLE
Update README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.19]
+## [0.19] - 2019-12-10
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ to run up to 3 parallel forks. The `cucumberTest` source set will depend on the 
 ```groovy
 plugins {
     id 'java'
-    id 'com.patdouble.cucumber-jvm' version '0.18'
+    id 'com.patdouble.cucumber-jvm' version '0.19'
 }
 
 addCucumberSuite 'cucumberTest'
@@ -54,9 +54,9 @@ repositories {
 }
 
 dependencies {
-    cucumberTestCompile 'io.cucumber:cucumber-java:4.8.0'
+    cucumberTestImplementation 'io.cucumber:cucumber-java:4.8.0'
     // To use JUnit assertions in the step definitions:
-    cucumberTestCompile 'junit:junit:4.12'
+    cucumberTestImplementation 'junit:junit:4.12'
 }
 ```
 
@@ -69,7 +69,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "com.patdouble:gradle-cucumber-jvm-plugin:0.18"
+        classpath "com.patdouble:gradle-cucumber-jvm-plugin:0.19"
     }
 }
 apply plugin: 'cucumber-jvm'
@@ -105,7 +105,7 @@ An example `build.gradle.kts` file might look like this:
 ```kotlin
 plugins {
     id("java")
-    id("com.patdouble.cucumber-jvm").version("0.18")
+    id("com.patdouble.cucumber-jvm").version("0.19")
 }
 
 cucumber {
@@ -118,8 +118,8 @@ repositories {
 }
 
 dependencies {
-    add("cucumberTestCompile", "io.cucumber:cucumber-java:4.8.0")
-    add("cucumberTestCompile", "junit:junit:4.12")
+    add("cucumberTestImplementation", "io.cucumber:cucumber-java:4.8.0")
+    add("cucumberTestImplementation", "junit:junit:4.12")
 }
 ```
 

--- a/src/integTest/groovy/com/commercehub/gradle/cucumber/CucumberIntegrationSpec.groovy
+++ b/src/integTest/groovy/com/commercehub/gradle/cucumber/CucumberIntegrationSpec.groovy
@@ -95,13 +95,16 @@ class CucumberIntegrationSpec extends IntegrationSpec {
 
     def testReportsDirectoryCreated() {
         given:
-        copyResources('testfeatures/happypath.feature', 'src/test/resoucres/features/happypath.feature')
+        copyResources('testfeatures/happypath.feature', 'src/test/resources/features/happypath.feature')
 
         when:
         ExecutionResult result = runTasksSuccessfully('test')
 
         then:
         fileExists('build/reports/test/cucumber-html-reports/overview-features.html')
+        fileExists('build/reports/test/cucumber-html-reports/overview-failures.html')
+        fileExists('build/reports/test/cucumber-html-reports/overview-steps.html')
+        fileExists('build/reports/test/cucumber-html-reports/overview-tags.html')
     }
 
 }

--- a/src/integTest/groovy/com/commercehub/gradle/cucumber/CucumberParallelSpec.groovy
+++ b/src/integTest/groovy/com/commercehub/gradle/cucumber/CucumberParallelSpec.groovy
@@ -107,13 +107,16 @@ class CucumberParallelSpec extends IntegrationSpec {
 
     def testReportsDirectoryCreated() {
         given:
-        copyResources('testfeatures/happypath.feature', 'src/cucumberTest/resoucres/features/happypath.feature')
+        copyResources('testfeatures/happypath.feature', 'src/cucumberTest/resources/features/happypath.feature')
 
         when:
         ExecutionResult result = runTasksSuccessfully('cucumberTest')
 
         then:
         fileExists('build/reports/cucumberTest/cucumber-html-reports/overview-features.html')
+        fileExists('build/reports/cucumberTest/cucumber-html-reports/overview-failures.html')
+        fileExists('build/reports/cucumberTest/cucumber-html-reports/overview-steps.html')
+        fileExists('build/reports/cucumberTest/cucumber-html-reports/overview-tags.html')
     }
 
     def testJunitReport() {


### PR DESCRIPTION
README has errors:
* wrong plugin version, change 0.18 -> 0.19
* issue #7 , wrong dependency scope (deprecated and not used anymore), change `compile` -> `implementation`